### PR TITLE
Fix packet 0x1F uuid endianness

### DIFF
--- a/docs/networking/packets/31-hotbar-item-changed.mdx
+++ b/docs/networking/packets/31-hotbar-item-changed.mdx
@@ -17,5 +17,5 @@ This packet is sent when the player equips a different item. No packet is sent w
 | Offset | Field Name       | Field Type | Notes |
 |--------|------------------|------------|-------|
 | 0x00   | Character ID     | be u32     | The character ID of the player sending the packet. |
-| 0x04   | Uuid             | be u128    | The UUID of the newly equiped item. `00000000-0000-0000-0000-000000000000` when no item is equipped |
+| 0x04   | Uuid             | le u128    | The UUID of the newly equiped item. `00000000-0000-0000-0000-000000000000` when no item is equipped |
 | 0x14   | Tool Instance ID | be u32     | The instance id of the newly equiped tool. Always `0xFFFFFFFF` for items that are not tools or when no item is equipped. |


### PR DESCRIPTION
I got the endianness wrong for the Uuid, it is actually little endian.

<!-- insert PR description above -->
-----
<a href="https://stackblitz.com/~/github.com/scrap-mechanic-modding/scrap-mechanic-modding.github.io/tree/TechnologicNick%2Fpatch-94190"><img src="https://developer.stackblitz.com/img/review_pr_small.svg" alt="Review PR in StackBlitz Codeflow" align="left" width="103" height="20"></a> _Submitted with [StackBlitz Codeflow](https://stackblitz.com/~/github.com/scrap-mechanic-modding/scrap-mechanic-modding.github.io/tree/TechnologicNick%2Fpatch-94190)._