### PR TITLE
fix catastrophic spelling error

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
 ## Unofficial Documentation for Scrap Mechanic
-Live version of this repository can be foudn [here](https://docs.scrapmods.io/).
+Live version of this repository can be found [here](https://docs.scrapmods.io/).
 
 When making changes to this repository, please use [StackBlitz](https://pr.new/github.com/Scrap-Mechanic-Modding/Scrap-Mechanic-Modding.github.io).


### PR DESCRIPTION
somehow this made it through Meowlan's extensive review process, definitely not my fault.

<!-- insert PR description above -->
-----
<a href="https://stackblitz.com/~/github.com/scrap-mods/docs/tree/massive-spelling-mistake-fix-Prime"><img src="https://developer.stackblitz.com/img/review_pr_small.svg" alt="Review PR in StackBlitz" align="left" width="103" height="20"></a> _Submitted with [StackBlitz](https://stackblitz.com/~/github.com/scrap-mods/docs/tree/massive-spelling-mistake-fix-Prime)._